### PR TITLE
chore: strengthen Kite AI privacy disclosures for Play / App Store

### DIFF
--- a/src/pages/privacy.mdx
+++ b/src/pages/privacy.mdx
@@ -73,7 +73,15 @@ export const contactEmail = "hello@tinykite.co";
         *   **Telemetry / analytics**: none. The app makes no requests to TinyKite-controlled servers.
         *   **Permissions requested**: camera and photo library (to attach images to messages), microphone and speech recognition (for dictation). All permissions are optional — denying them only disables the corresponding feature.
 
-        For App Store privacy nutrition label purposes: data linked to you = none collected by TinyKite. Data not linked to you = none collected by TinyKite. Data collected by third-party model providers is governed by their respective policies.
+        **AI-generated content disclosure.** Responses in Kite AI are produced by third-party large language models. They may be inaccurate, incomplete, biased, or otherwise inappropriate. Kite AI does not pre-screen or moderate model output beyond what the chosen provider applies; we expose the provider's response as-is. Users should verify any information that matters before relying on it. Each assistant message includes a "Report" affordance that lets you flag content; reported items are summarized to your clipboard for emailing to {contactEmail} so we can investigate and adjust providers or guidance accordingly.
+
+        **Children's audience.** Kite AI is not directed at children under 13 (or under 16 in the EEA / UK). We do not knowingly collect data from children. If you believe a child has supplied data through the app, contact us at {contactEmail} and we will help locate and remove it.
+
+        **Data deletion.** Because Kite AI does not collect or store your data on TinyKite servers, you can delete all of your in-app data at any time by uninstalling the app. To delete a synced GitHub repository, sign in to GitHub and remove the `kite-ai-conversations` (or your custom-named) repository directly. To revoke API keys, do so at the provider's dashboard. For any additional deletion request, email {contactEmail}.
+
+        **Account deletion.** Kite AI does not require an account, so there is no separate "delete account" flow — uninstalling the app and rotating any provider API keys you supplied is sufficient.
+
+        For App Store privacy nutrition label purposes: data linked to you = none collected by TinyKite. Data not linked to you = none collected by TinyKite. Data collected by third-party model providers is governed by their respective policies. For Google Play Data Safety: messages are sent to user-selected AI providers over HTTPS and not collected by TinyKite; no other data types are collected.
 
         ## 9. Contact Us
 


### PR DESCRIPTION
Adds AI-content disclosure, children's-audience clause, data-deletion mechanics, and a Google Play Data Safety paragraph alongside the existing App Store nutrition-label one. Defensive — both Apple and Google scrutinize these on AI chat reviews.