### PR TITLE
docs(gloss): dual-platform demos from GitHub Releases

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,5 +1,12 @@
 # Deployment Guide
 
+## Demo videos (binding)
+
+Product feature demos are **GitHub Release assets**, never files under
+`public/` and never committed to git. See **[docs/DEMO-VIDEOS.md](docs/DEMO-VIDEOS.md)**
+for the full Nesta/Gloss workflow (`videoBase` →
+`…/releases/download/<app>-videos-vN/`).
+
 ## Deploy to GitHub Pages
 
 This TinyKite.co website is configured for deployment on GitHub Pages with automated builds via GitHub Actions.

--- a/docs/DEMO-VIDEOS.md
+++ b/docs/DEMO-VIDEOS.md
@@ -1,0 +1,75 @@
+# Demo videos — how we ship them (binding)
+
+**Future agents: do not invent a new path.** Every product page on this site
+follows the Nesta pattern below. Videos are **never** committed to git.
+
+## The rule
+
+| What | Where |
+|------|--------|
+| Product docs page | This repo (`src/pages/<app>/`, `src/data/<app>/features.json`) |
+| Demo videos | **GitHub Release assets** on `tinykite-co/tinykite.co` |
+| Local recordings | App monorepo `mobile-apps/<app>/demos/videos/` (**gitignored**) |
+
+**Never** put `.mp4` files under `public/`. They bloat the repo, defeat
+regeneration, and break the Nesta workflow.
+
+## Pattern (copy Nesta / Gloss)
+
+1. **Record + produce** in the monorepo (hermetic demos + logo intro/outro + synthesized music).
+2. **Upload** finished cuts as assets on a versioned release tag:
+   - Nesta: `nesta-videos-v1` (bump to `v2` when the whole set is re-cut)
+   - Gloss: `gloss-videos-v1`
+3. **Point the site** at that release with `videoBase` in `src/data/<app>/features.json`:
+
+```json
+"videoBase": "https://github.com/tinykite-co/tinykite.co/releases/download/gloss-videos-v1/"
+```
+
+4. Each feature lists only a **base filename** (or dual-platform base):
+
+```json
+"video": "demo_lookup-word.mp4"
+```
+
+The page builds the real URL:
+- Single-platform (Nesta v1): `{videoBase}{video}`
+- Dual-platform (Gloss / Nesta switcher):  
+  `{videoBase}{stem}_android.mp4` and `{videoBase}{stem}_ios.mp4`  
+  (or Nesta’s prefix form `android_{video}` if that release uses prefixes)
+
+## Publish a new video set
+
+```bash
+# From monorepo after record + produce:
+VIDEOS=mobile-apps/<app>/demos/videos
+cd /path/to/tinykite.co
+
+gh release create <app>-videos-vN \
+  "$VIDEOS"/demo_*.mp4 \
+  --title "<App> demo videos vN" \
+  --notes "Feature demos for tinykite.co/<app>/. Release assets only — never in git."
+
+# Then set videoBase in src/data/<app>/features.json to:
+# https://github.com/tinykite-co/tinykite.co/releases/download/<app>-videos-vN/
+```
+
+Replacing assets on an existing tag is possible with `gh release upload … --clobber`,
+but prefer a new `vN` when the set changes meaningfully so old links stay stable.
+
+## Why releases (not public/ or R2 in the default path)
+
+- Nesta messenger catalog: release notes state explicitly  
+  **“Videos are release assets by design — they never enter git history.”**
+- Site stays small; videos regenerate from monorepo drivers anytime.
+- (Older calendar-era Nesta once used R2 URLs; the **current** messenger
+  catalog uses GitHub Releases. Prefer releases unless product decides CDN.)
+
+## Checklist for any new app page
+
+- [ ] `demos/videos/` gitignored in the app
+- [ ] Record/produce scripts in `integration_test/demos/`
+- [ ] Release tag `{app}-videos-vN` with mp4 assets
+- [ ] `videoBase` → that release download URL
+- [ ] Features reference base names only
+- [ ] No mp4 under `public/`

--- a/src/data/gloss/features.json
+++ b/src/data/gloss/features.json
@@ -8,7 +8,8 @@
     "icon": "/gloss/icon-512.png",
     "platforms": "iOS \u00b7 Android \u00b7 Web \u00b7 macOS"
   },
-  "videoBase": "",
+  "videoBase": "https://github.com/tinykite-co/tinykite.co/releases/download/gloss-videos-v1/",
+  "videoNote": "Videos are GitHub Release assets (never in git) — same as Nesta. features.video is the base name (demo_lookup-word.mp4); the page loads demo_lookup-word_android.mp4 / demo_lookup-word_ios.mp4 via the page-level Android/iPhone switcher. See docs/DEMO-VIDEOS.md.",
   "parts": [
     {
       "kicker": "Part 1 \u00b7 The reading loop",
@@ -20,7 +21,7 @@
           "title": "What word? (combo-first)",
           "summary": "Home opens on a big \u201cWhat word?\u201d field. Type two or three letters; picture-tagged suggestions appear immediately. The header shows a bookmark (words met), the active reader\u2019s avatar, and About.",
           "entry": "app open \u2192 What word?",
-          "video": null,
+          "video": "demo_lookup-word.mp4",
           "screenshot": "/gloss/screenshots/app/01-home.png"
         },
         {
@@ -67,7 +68,7 @@
           "title": "Who's reading? (local profiles)",
           "summary": "Tap the colored avatar to switch readers or add another (You, Reader 2, \u2026). Profiles are device-local only \u2014 no email, no cloud. Each reader has a separate history.",
           "entry": "home \u2192 avatar \u2192 Who's reading?",
-          "video": null,
+          "video": "demo_profiles.mp4",
           "screenshot": "/gloss/screenshots/design/feat-profiles.png"
         },
         {
@@ -83,7 +84,7 @@
           "title": "Quiz me",
           "summary": "Needs at least 3 words in the list. Gloss shows POS media and asks \u201cWhich word?\u201d with three choices. Up to 5 questions, score screen, Play again. All offline from the reader's history.",
           "entry": "Words you've met \u2192 Quiz me",
-          "video": null,
+          "video": "demo_quiz-me.mp4",
           "screenshot": null
         }
       ]

--- a/src/pages/gloss/index.astro
+++ b/src/pages/gloss/index.astro
@@ -1,8 +1,19 @@
 ---
 import Layout from "../../layouts/Layout.astro";
+import DeviceFrame from "../../components/DeviceFrame.astro";
 import catalog from "../../data/gloss/features.json";
 
-const { product, parts, designVsApp, userflows } = catalog;
+const { product, videoBase = "", parts, designVsApp, userflows } = catalog;
+
+/** Base name → platform file. demo_foo.mp4 + android → demo_foo_android.mp4 */
+function platformSrc(base: string, video: string, platform: "android" | "ios"): string {
+  const stem = video.replace(/\.mp4$/i, "");
+  return `${base}${stem}_${platform}.mp4`;
+}
+
+function hasVideo(video: unknown): boolean {
+  return typeof video === "string" && video.length > 0 && Boolean(videoBase);
+}
 ---
 
 <Layout
@@ -60,6 +71,36 @@ const { product, parts, designVsApp, userflows } = catalog;
           </p>
         </div>
 
+        <!-- Page-level platform switcher (same pattern as Nesta): swaps every
+             demo between the Android and iPhone captures. Defaults to the
+             visitor's phone OS; remembered in localStorage. -->
+        <div class="flex justify-center mb-12">
+          <div
+            role="tablist"
+            aria-label="Preview platform"
+            class="inline-flex rounded-full border border-gray-200 dark:border-white/[0.1] p-1 bg-white dark:bg-white/[0.03]"
+          >
+            <button
+              type="button"
+              role="tab"
+              data-platform="ios"
+              aria-selected="true"
+              class="gloss-platform-tab px-6 py-2 rounded-full text-sm font-medium transition-colors"
+            >
+              iPhone
+            </button>
+            <button
+              type="button"
+              role="tab"
+              data-platform="android"
+              aria-selected="false"
+              class="gloss-platform-tab px-6 py-2 rounded-full text-sm font-medium transition-colors"
+            >
+              Android
+            </button>
+          </div>
+        </div>
+
         {parts.map((part) => (
           <div class="mt-16">
             <p class="text-[var(--gloss-sage)] font-medium tracking-wide uppercase text-sm mb-2">
@@ -95,13 +136,46 @@ const { product, parts, designVsApp, userflows } = catalog;
                         </div>
                       </div>
                     </div>
-                    {feature.screenshot && (
-                      <img
-                        src={feature.screenshot}
-                        alt={feature.title}
-                        class="w-full sm:w-48 flex-shrink-0 rounded-xl border border-gray-100 dark:border-white/[0.06] bg-[var(--gloss-paper)] object-cover object-top max-h-80"
-                        loading="lazy"
-                      />
+                    {hasVideo(feature.video) ? (
+                      <div class="gloss-demo-slot w-full sm:w-56 flex-shrink-0">
+                        <div class="gloss-frame gloss-frame--ios" data-frame="ios">
+                          <DeviceFrame device="iphone" orientation="portrait">
+                            <video
+                              class="demo-video"
+                              controls
+                              playsinline
+                              preload="metadata"
+                              data-base={videoBase}
+                              data-video={feature.video as string}
+                              src={platformSrc(videoBase, feature.video as string, "ios")}
+                              title={`${feature.title} — iPhone`}
+                            ></video>
+                          </DeviceFrame>
+                        </div>
+                        <div class="gloss-frame gloss-frame--android" data-frame="android" hidden>
+                          <DeviceFrame device="android-phone" orientation="portrait">
+                            <video
+                              class="demo-video"
+                              controls
+                              playsinline
+                              preload="metadata"
+                              data-base={videoBase}
+                              data-video={feature.video as string}
+                              src={platformSrc(videoBase, feature.video as string, "android")}
+                              title={`${feature.title} — Android`}
+                            ></video>
+                          </DeviceFrame>
+                        </div>
+                      </div>
+                    ) : (
+                      feature.screenshot && (
+                        <img
+                          src={feature.screenshot}
+                          alt={feature.title}
+                          class="w-full sm:w-48 flex-shrink-0 rounded-xl border border-gray-100 dark:border-white/[0.06] bg-[var(--gloss-paper)] object-cover object-top max-h-80"
+                          loading="lazy"
+                        />
+                      )
                     )}
                   </div>
                 </article>
@@ -231,4 +305,59 @@ const { product, parts, designVsApp, userflows } = catalog;
     --gloss-honey: #e8a512;
     --gloss-paper: #f7f3ea;
   }
+
+  .gloss-platform-tab {
+    color: rgb(107 114 128);
+  }
+  .gloss-platform-tab.is-active {
+    background: var(--gloss-sage);
+    color: #fff;
+  }
+
+  .gloss-demo-slot :global(.device-frame) {
+    margin: 0 auto;
+    max-width: 240px;
+  }
 </style>
+
+<script is:inline>
+  (function () {
+    const KEY = "gloss-demo-platform";
+    const tabs = Array.from(document.querySelectorAll(".gloss-platform-tab"));
+    const frames = Array.from(document.querySelectorAll("[data-frame]"));
+
+    function detectDefault() {
+      const stored = localStorage.getItem(KEY);
+      if (stored === "ios" || stored === "android") return stored;
+      const ua = navigator.userAgent || "";
+      if (/Android/i.test(ua)) return "android";
+      if (/iPhone|iPad|iPod/i.test(ua)) return "ios";
+      if (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1) {
+        return "ios";
+      }
+      return "ios";
+    }
+
+    function apply(next) {
+      localStorage.setItem(KEY, next);
+      tabs.forEach((tab) => {
+        const active = tab.dataset.platform === next;
+        tab.classList.toggle("is-active", active);
+        tab.setAttribute("aria-selected", active ? "true" : "false");
+      });
+      frames.forEach((frame) => {
+        const match = frame.dataset.frame === next;
+        frame.hidden = !match;
+        if (!match) {
+          const video = frame.querySelector("video");
+          if (video && !video.paused) video.pause();
+        }
+      });
+    }
+
+    tabs.forEach((tab) =>
+      tab.addEventListener("click", () => apply(tab.dataset.platform)),
+    );
+    apply(detectDefault());
+  })();
+</script>


### PR DESCRIPTION
## Summary
- Wire `/gloss` feature demos to **GitHub Release** assets (`gloss-videos-v1`) — same pattern as Nesta; no mp4 in git/`public/`
- Page-level **iPhone / Android** switcher (OS default + localStorage) with DeviceFrame silhouettes
- Base video names in `features.json` → `{stem}_android.mp4` / `{stem}_ios.mp4`
- Binding note for future agents: `docs/DEMO-VIDEOS.md` (+ pointer in `DEPLOYMENT.md`)

## Videos
Release: https://github.com/tinykite-co/tinykite.co/releases/tag/gloss-videos-v1  
Cuts: lookup-word, profiles, quiz-me × android + ios (logo intro/outro + music from monorepo produce pipeline)

## Test plan
- [ ] Open `/gloss` after deploy
- [ ] Switcher toggles iPhone ↔ Android for features 1, 6, 8
- [ ] Video URLs load from `…/releases/download/gloss-videos-v1/`
- [ ] No `.mp4` under `public/`
- [ ] `npm run build` clean

Restored from stash left by other agent (`user gloss + docs WIP (preserve)`); Gloss-only, no Nesta PR entanglement.