### PR TITLE
fix(gloss): remove internal pixel audit from public docs

### DIFF
--- a/src/data/gloss/features.json
+++ b/src/data/gloss/features.json
@@ -152,24 +152,6 @@
       ]
     }
   ],
-  "designVsApp": {
-    "title": "Design vs build \u2014 pixel audit",
-    "summary": "Compared Gloss.dc.html (including profiles/quiz update) against the Flutter app.",
-    "matches": [
-      "Home: wordmark, bookmark count, profile avatar, info",
-      "Local profiles sheet + per-reader history",
-      "Words you've met + Quiz me (\u22653)",
-      "Quiz media \u2192 Which word? \u2192 score",
-      "Combo field, POS suggestions, not-found card, meaning layout"
-    ],
-    "gaps": [
-      "Brand mark G monogram SVG not yet in Flutter header",
-      "Keyboard-open layout can overflow against the mic",
-      "Info toggles still visual-only",
-      "Paper Night theme not exposed as ThemeMode",
-      "POS media still placeholders until editorial packs"
-    ]
-  },
   "userflows": [
     {
       "id": "happy-type",

--- a/src/pages/gloss/index.astro
+++ b/src/pages/gloss/index.astro
@@ -3,7 +3,7 @@ import Layout from "../../layouts/Layout.astro";
 import DeviceFrame from "../../components/DeviceFrame.astro";
 import catalog from "../../data/gloss/features.json";
 
-const { product, videoBase = "", parts, designVsApp, userflows } = catalog;
+const { product, videoBase = "", parts, userflows } = catalog;
 
 /** Base name → platform file. demo_foo.mp4 + android → demo_foo_android.mp4 */
 function platformSrc(base: string, video: string, platform: "android" | "ios"): string {
@@ -211,68 +211,6 @@ function hasVideo(video: unknown): boolean {
               </ol>
             </div>
           ))}
-        </div>
-      </div>
-    </section>
-
-    <!-- Design vs app audit -->
-    <section class="py-16 px-6">
-      <div class="container mx-auto max-w-5xl">
-        <h2 class="text-3xl font-bold text-text mb-3" style="font-family: 'Lora', serif;">
-          {designVsApp.title}
-        </h2>
-        <p class="text-gray-600 dark:text-gray-400 mb-10 max-w-2xl">
-          {designVsApp.summary}
-        </p>
-
-        <div class="grid md:grid-cols-2 gap-6 mb-12">
-          <div class="rounded-2xl border border-emerald-200/60 dark:border-emerald-500/20 bg-emerald-50/50 dark:bg-emerald-500/5 p-6">
-            <h3 class="font-semibold text-emerald-800 dark:text-emerald-300 mb-4">Matches design</h3>
-            <ul class="space-y-2.5">
-              {designVsApp.matches.map((item) => (
-                <li class="text-sm text-gray-700 dark:text-gray-300 leading-relaxed flex gap-2">
-                  <span class="text-emerald-600 dark:text-emerald-400 flex-shrink-0">✓</span>
-                  <span>{item}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-          <div class="rounded-2xl border border-amber-200/60 dark:border-amber-500/20 bg-amber-50/50 dark:bg-amber-500/5 p-6">
-            <h3 class="font-semibold text-amber-900 dark:text-amber-300 mb-4">Still off / open</h3>
-            <ul class="space-y-2.5">
-              {designVsApp.gaps.map((item) => (
-                <li class="text-sm text-gray-700 dark:text-gray-300 leading-relaxed flex gap-2">
-                  <span class="text-amber-600 dark:text-amber-400 flex-shrink-0">→</span>
-                  <span>{item}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-        </div>
-
-        <div class="grid sm:grid-cols-2 gap-4">
-          <figure class="rounded-2xl overflow-hidden border border-gray-100 dark:border-white/[0.06]">
-            <img
-              src="/gloss/screenshots/design/design-prototype-area.png"
-              alt="Design prototype area from Gloss.dc.html"
-              class="w-full object-cover object-top max-h-72"
-              loading="lazy"
-            />
-            <figcaption class="text-xs text-gray-500 px-3 py-2 bg-gray-50 dark:bg-white/[0.03]">
-              Design pack — interactive prototype (Gloss.dc.html)
-            </figcaption>
-          </figure>
-          <figure class="rounded-2xl overflow-hidden border border-gray-100 dark:border-white/[0.06]">
-            <img
-              src="/gloss/screenshots/app/01-home.png"
-              alt="Flutter app home screen"
-              class="w-full object-cover object-top max-h-72 bg-[var(--gloss-paper)]"
-              loading="lazy"
-            />
-            <figcaption class="text-xs text-gray-500 px-3 py-2 bg-gray-50 dark:bg-white/[0.03]">
-              Build — Flutter home (phone frame, 390×844)
-            </figcaption>
-          </figure>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Drop the **Design vs build — pixel audit** section from the public `/gloss` page
- Remove `designVsApp` from the public features catalog

That content is internal engineering notes (gaps, design-pack comparison), not something visitors should see.

## Test plan
- [ ] `/gloss` has no pixel-audit / “Still off” section
- [ ] Feature catalog + demos + user flows still render